### PR TITLE
Fixes for remotehost and post-process

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -41,25 +41,25 @@ while true; do
             ;;
         --protocol)
             shift;
-            protocol=$protocol
+            protocol=$1
             echo "protocol=$protocol"
             shift
             ;;
         --wsize)
             shift;
-            wsize=$wsize
+            wsize=$1
             echo "wsize=$wsize"
             shift
             ;;
         --remotehost)
             shift;
-            remotehost=$remotehost
+            remotehost=$1
             echo "remotehost=$remotehost"
             shift
             ;;
         --duration)
             shift;
-            duration=$duration
+            duration=$1
             echo "duration=$duration"
             shift
             ;;

--- a/uperf-post-process
+++ b/uperf-post-process
@@ -40,14 +40,14 @@ if ( -e $result_file) {
         if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
             $ts = $1, $bytes = $2, $ops = $3;
             if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
-                my %sample = ('end' => $ts, 'value' =>  ($bytes - $prev_bytes) / $ts_diff / 125000);
+                my %sample = ('end' => int $ts, 'value' =>  0.0 + ($bytes - $prev_bytes) / $ts_diff / 125000);
                 push(@{ $metric_types{'Gbps'}{'data'} }, \%sample);
                 if ($test_type eq "rr") {
                     my $tps = ($ops - $prev_ops) / $ts_diff / 2;
-                    my %sample = ('end' => $ts, 'value' => $tps);
+                    my %sample = ('end' => int $ts, 'value' => (0.0 + $tps));
                     push(@{ $metric_types{'trans-sec'}{'data'} }, \%sample);
                     my $lat = $nthreads / $tps *1000000;
-                    %sample = ('end' => $ts, 'value' => $lat);
+                    %sample = ('end' => int $ts, 'value' => (0.0 + $lat));
                     push(@{ $metric_types{'latency'}{'data'} }, \%sample);
                 }
             }
@@ -77,6 +77,7 @@ if ( -e $result_file) {
 my %sample;
 my @periods;
 my %period = ('name' => 'measurement');
+$sample{'rickshaw-bench-metric'}{'schema'}{'version'} = "2020.03.18";
 $period{'metrics'} = \@metrics;
 push(@periods, \%period);
 $sample{'periods'} = \@periods;

--- a/xml-files/stream.xml
+++ b/xml-files/stream.xml
@@ -2,7 +2,7 @@
 <profile name="netperf">
   <group nthreads="$nthreads">
     <transaction iterations="1">
-      <flowop type="connect" options="remotehost=localhost protocol=tcp"/>
+      <flowop type="connect" options="remotehost=$remotehost protocol=tcp"/>
     </transaction>
     <transaction duration="10">
       <flowop type="write" options="count=256 size=$wsize"/>


### PR DESCRIPTION
-Actually use the remote host in the uperf-client and the xml file
-Ensure ints and floats are used in metrics
-Include {'rickshaw-bench-metric'}{'schema'}{'version'} = "2020.03.18"} in the metric document