### PR TITLE
Big update to support variable roadblock timeout and server IP

### DIFF
--- a/rickshaw.json
+++ b/rickshaw.json
@@ -1,7 +1,7 @@
 {
     "rickshaw-benchmark": {
         "schema": {
-            "version": "2020.04.14"
+            "version": "2020.05.18"
         }
     },
     "benchmark": "uperf",
@@ -11,6 +11,10 @@
     "client": {
         "files-from-controller": [
             {
+                "src": "%bench-dir%/uperf-get-runtime",
+                "dest": "/usr/bin/"
+            },
+            {
                 "src": "%bench-dir%/uperf-client",
                 "dest": "/usr/bin/"
             },
@@ -19,6 +23,7 @@
                 "dest": "/tmp/"
             }
         ],
+        "runtime": "uperf-get-runtime",
         "start": "uperf-client"
     },
     "server": {

--- a/uperf-client
+++ b/uperf-client
@@ -3,13 +3,22 @@ exec >uperf-client-stderrout.txt
 exec 2>&1
 
 echo "args: $@"
+echo
 if [ -z "$RS_CS_LABEL" ]; then
     echo "RS_CS_LABEL is not defined, exiting"
     exit 1
 else
     echo "RS_CS_LABEL: $RS_CS_LABEL"
+    echo
 fi
 echo "hostname: `hostname`"
+echo
+echo "pwd:"
+/bin/pwd
+echo
+echo "ls -alR:"
+/bin/ls -alR
+echo
 # defaults
 nthreads=1
 protocol=tcp
@@ -17,9 +26,10 @@ wsize=1024
 rsize=1024
 duration=60
 remotehost=""
+server_ifname="eth0"
 test_type=stream
 
-longopts="test-type:,protocol:,wsize:,nthreads:,remotehost:,duration:"
+longopts="test-type:,protocol:,wsize:,nthreads:,remotehost:,duration:,server-ifname:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     printf -- "\tUnrecognized option specified\n\n"
@@ -62,6 +72,12 @@ while true; do
             echo "remotehost=$remotehost"
             shift
             ;;
+        --server-ifname)
+            shift;
+            server_ifname=$1
+            echo "server_ifname=$server_ifname"
+            shift
+            ;;
         --duration)
             shift;
             duration=$1
@@ -79,7 +95,19 @@ while true; do
 done
 
 if [ -z "$remotehost" ]; then
-    echo "rmotehost is not set"
+    echo "Remotehost was not set via cmdline args, checking any messages from server"
+    if [ -e "msgs/rx/client-start:1" ]; then
+        echo "Found msgs/rx/client-start:1"
+        ipaddr=`jq -r '.iproute[] | select(.ifname == "'$server_ifname'") | .addr_info[] | select(.family == "inet") | .local' "msgs/rx/client-start:1"`
+        if [ ! -z "$ipaddr" ]; then
+            echo "Found server IP $ipaddr"
+            remotehost=$ipaddr
+        fi
+    fi
+fi
+
+if [ -z "$remotehost" ]; then
+    echo "remotehost is not set"
     exit 1
 fi
 
@@ -98,5 +126,6 @@ fi
 
 let "port = 5 * $id"
 let "port = $port + 20000"
+/bin/cp /tmp/xml-files/$test_type.xml test.xml
 nthreads=$nthreads protocol=$protocol remotehost=$remotehost duration=$duration \
-    wsize=$wsize uperf -m /tmp/xml-files/$test_type.xml -P $port
+    wsize=$wsize uperf -m test.xml -P $port

--- a/uperf-get-runtime
+++ b/uperf-get-runtime
@@ -1,0 +1,23 @@
+#!/bin/bash
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+duration=60
+opts=$(getopt -q -o "" --longoptions "duration:" -n "getopt.sh" -- "$@");
+eval set -- "$opts";
+while true; do
+    case "$1" in
+        --duration)
+            shift
+            duration=$1
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+echo $duration

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -2,6 +2,13 @@
 exec >uperf-server-stderrout.txt 
 exec 2>&1
 echo "args; $@"
+echo
+echo "pwd:"
+/bin/pwd
+echo
+echo "ls -alR:"
+ls -alR
+echo
 if [ -z "$RS_CS_LABEL" ]; then
     echo "RS_CS_LABEL not defined, exiting"
     exit 1
@@ -9,14 +16,23 @@ else
     echo "RS_CS_LABEL: $RS_CS_LABEL"
 fi
 echo "hostname: `hostname`"
+echo
 id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
 re='^[1-9][0-9]*$'
 if [[ ! "$id" =~ $re ]]; then
     echo "ID must a be a positive interger, exiting"
     exit 1
 fi
+
+# Queue ip info, to be sent to client
+echo '{"recipient":{"type":"all","id":"all"},"user-object":{"iproute":' >msgs/tx/ip
+ip -j a >>msgs/tx/ip
+echo '}}' >>msgs/tx/ip
+
+# Calculate port
 let "port = 5 * $id"
 let "port = $port + 20000"
+
 cmd="uperf -s -P $port"
 echo "going to run: $cmd"
 $cmd 2>&1 >uperf-server-start.txt &

--- a/workshop.json
+++ b/workshop.json
@@ -8,7 +8,8 @@
 	    {
 	        "name": "default",
 	        "requirements": [
-            "uperf_src"
+            "uperf_src",
+            "iproute"
 	        ]
 	    }
     ],
@@ -31,6 +32,15 @@
 		            ]
                 }
 	        }
+        },
+	    {
+	        "name": "iproute",
+	        "type": "distro",
+	        "distro_info": {
+                "packages": [
+                    "iproute"
+                ]
+            }
         }
     ]
 }

--- a/xml-files/stream.xml
+++ b/xml-files/stream.xml
@@ -2,9 +2,9 @@
 <profile name="netperf">
   <group nthreads="$nthreads">
     <transaction iterations="1">
-      <flowop type="connect" options="remotehost=$remotehost protocol=tcp"/>
+      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol"/>
     </transaction>
-    <transaction duration="10">
+    <transaction duration="$duration">
       <flowop type="write" options="count=256 size=$wsize"/>
     </transaction>
     <transaction iterations="1">


### PR DESCRIPTION
-Rickshaw will run a command/script found in client.runtime
 to have the client output the amojunt of time in seconds
 it expects the test to take.  Uperf uses 'uperf-get-runtime'
 to do this.
-Rickshaw now supports the ability for benchmark scripts to
 queue up messages which will be sent by roadblock.  Clients
 can send messages to their server and servers can send messages
 to their client.  The 'uperf-server-start' script will
 generate output in JSON for 'ip -a' and queue this up to
 send.  The script 'uperf-client', when this message is
 detected, will parse it and find the IP address for --server-ifname
 if that option was part of the benchmark params.  If not,
 the bench param --remotehost can still be used (but does
 not really work if you have mutliple client/server pairs
 on different hosts).
-The script 'uperf-client' will copy the test xml file
 to the local directory so it is saved with the results.