### PR TITLE
This prepares uperf to support endpoints passing along info to client

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -26,6 +26,8 @@ wsize=1024
 rsize=1024
 duration=60
 remotehost=""
+control_port=""
+data_port=""
 server_ifname="eth0"
 test_type=""
 
@@ -100,14 +102,32 @@ while true; do
     esac
 done
 
+id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
+re='^[1-9][0-9]*$'
+if [[ ! "$id" =~ $re ]]; then
+    echo "ID must a be a positive interger, exiting"
+    exit 1
+fi
+
 if [ -z "$remotehost" ]; then
-    echo "Remotehost was not set via cmdline args, checking any messages from server"
-    if [ -e "msgs/rx/client-start:1" ]; then
-        echo "Found msgs/rx/client-start:1"
-        ipaddr=`jq -r '.iproute[] | select(.ifname == "'$server_ifname'") | .addr_info[] | select(.family == "inet") | .local' "msgs/rx/client-start:1" | head -1`
+    echo "Remotehost was not set via cmdline args, checking any messages from server & endpoint"
+    file="msgs/rx/client-start:1"
+    if [ -e "$file" ]; then
+        echo "Found $file"
+        ipaddr=`jq -r '.svc.ip' $file`
         if [ ! -z "$ipaddr" ]; then
             echo "Found server IP $ipaddr"
             remotehost=$ipaddr
+        fi
+        port=`jq -r '.svc.ports[0]' $file`
+        if [ ! -z "$port" ]; then
+            echo "Found server control port $port"
+            control_port=$port
+        fi
+        port=`jq -r '.svc.ports[1]' $file`
+        if [ ! -z "$port" ]; then
+            echo "Found server data port $port"
+            data_port=$port
         fi
     fi
 fi
@@ -116,6 +136,15 @@ if [ -z "$remotehost" ]; then
     echo "remotehost is not set"
     exit 1
 fi
+if [ -z "$control_port" ]; then
+    let "control_port = 2 * $id"
+    let "control_port = $control_port + 30000"
+    echo "control_port was not set, using default of $control_port"
+fi
+if [ -z "$datal_port" ]; then
+    let "data_port = $control_port + 1"
+    echo "data_port was not set, using default of $data_port"
+fi
 
 test_xml="/tmp/xml-files/$test_type.xml"
 if [ ! -e $test_xml ]; then
@@ -123,15 +152,6 @@ if [ ! -e $test_xml ]; then
     exit 1
 fi
 
-id=`echo $RS_CS_LABEL | awk -F- '{print $2}'`
-re='^[1-9][0-9]*$'
-if [[ ! "$id" =~ $re ]]; then
-    echo "ID must a be a positive interger, exiting"
-    exit 1
-fi
-
-let "port = 5 * $id"
-let "port = $port + 20000"
 
 echo "test-xml-files:"
 /bin/ls /tmp/xml-files
@@ -142,10 +162,14 @@ ip a
 echo
 
 /bin/cp /tmp/xml-files/$test_type.xml test.xml
+echo "remotehost=$remotehost"
+echo "control_port=$control_port"
+echo "data_port=$data_port"
 nthreads=$nthreads \
 protocol=$protocol \
 remotehost=$remotehost \
 duration=$duration \
 wsize=$wsize \
 rsize=$rsize \
-uperf -m test.xml -P $port
+port=$data_port \
+uperf -m test.xml -P $control_port

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -24,20 +24,22 @@ if [[ ! "$id" =~ $re ]]; then
     exit 1
 fi
 
-# Queue ip info, to be sent to client
-echo '{"recipient":{"type":"all","id":"all"},"user-object":{"iproute":' >msgs/tx/ip
-ip -j a >>msgs/tx/ip
-echo '}}' >>msgs/tx/ip
+# There are always 2 ports for these uperf tests, and ports should always
+# start at 30000 to avoid port number reassignment
+let "control_port = 2 * $id"
+let "control_port = $control_port + 30000"
+let "data_port = $control_port + 1"
+
+#TODO: IP should be determined by $ifname (will need to add argparse) or first non-loopback IP found
+ip="192.168.1.1"
+# Queue ip/port info, to be sent to endpoint
+echo '{"recipient":{"type":"all","id":"all"},"user-object":{"svc":{"ip":"'$ip'","ports":['$control_port,$data_port']}}}' >msgs/tx/svc
 
 echo "ip a"
 ip a
 echo
 
-# Calculate port
-let "port = 5 * $id"
-let "port = $port + 20000"
-
-cmd="uperf -s -P $port"
+cmd="uperf -s -P $control_port"
 echo "going to run: $cmd"
 $cmd 2>&1 >uperf-server-start.txt &
 pid=$!
@@ -49,3 +51,8 @@ if grep -q -i error uperf-server-start.txt; then
     cat uperf-server-start.txt
     exit 1
 fi
+echo ps:
+ps aux | grep uperf
+echo
+echo ss -tlnp:
+ss -tlnp

--- a/xml-files/rr.xml
+++ b/xml-files/rr.xml
@@ -2,7 +2,7 @@
 <profile name="request-response">
   <group nthreads="$nthreads">
     <transaction iterations="1">
-      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol"/>
+      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol port=$port"/>
     </transaction>
     <transaction duration="$duration">
       <flowop type="write" options="size=$wsize"/>

--- a/xml-files/stream.xml
+++ b/xml-files/stream.xml
@@ -2,7 +2,7 @@
 <profile name="stream">
   <group nthreads="$nthreads">
     <transaction iterations="1">
-      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol"/>
+      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol port=$port"/>
     </transaction>
     <transaction duration="$duration">
       <flowop type="write" options="count=256 size=$wsize"/>


### PR DESCRIPTION
- Uperf now specifies a data port in the client command via env var
  - This ensures uperf uses exactly 1 data port regardless of the number of
    threads uperf uses
- This data port must be 30,000-60,000 to work with k8s
  - It is possible for a different port to work within a pod, but when
    exposing this port via "ingress" it would need to be remapped to the
    30,000-60,000 range.  The problem with this is that during a test
    setup, the uperf server sends the port number to the uperf client,
    and of the port is remapped to a different number via k8s, the port
    uperf server sends will not be correct.
- The XML test files must reference this data port var
- The uperf server script must send a message with the IP and ports used
- The rickshaw endpoints get this message and do any work to make the
  IP/ports accessible and send that info to the client
- The client has to read that message to know what IP/ports to use
- The client can skip all this if --remotehost is still used when running uperf