### PR TITLE
Use offical uperf src

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -173,4 +173,18 @@ duration=$duration \
 wsize=$wsize \
 rsize=$rsize \
 port=$data_port \
-uperf -m test.xml -P $control_port
+uperf -R -m test.xml -P $control_port &
+pid=$!
+sleep 10
+sleep $duration
+if [ -e /proc/$pid ]; then
+    echo "uperf client is still running, killing it"
+    kill $pid
+    sleep 3
+    if [ -e /proc/$pid ]; then
+        # hulk smash
+        kill -9 $pid
+    fi
+    exit 1
+fi
+exit 0

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -145,3 +145,4 @@ ps aux | grep uperf
 echo
 echo ss -tlnp:
 ss -tlnp
+exit 0

--- a/workshop.json
+++ b/workshop.json
@@ -18,13 +18,13 @@
 	        "name": "uperf_src",
 	        "type": "source",
 	        "source_info": {
-		        "url": "https://github.com/atheurer/uperf/archive/v1.0.6-amt2.tar.gz",
-		        "filename": "v1.0.6-amt2.tar.gz",
+		        "url": "https://github.com/uperf/uperf/archive/1.0.7.tar.gz",
+		        "filename": "1.0.7.tar.gz",
 		        "commands": { 
-		            "unpack": "tar -xzf v1.0.6-amt2.tar.gz",
-		            "get_dir": "tar -tzf v1.0.6-amt2.tar.gz | head -n 1",
+		            "unpack": "tar -xzf 1.0.7.tar.gz",
+		            "get_dir": "tar -tzf 1.0.7.tar.gz | head -n 1",
 		            "commands": [
-			            "CCFLAGS=\"-g\" ./configure --disable-sctp --enable-debug",
+			            "CFLAGS=\"-ggdb\" ./configure --disable-sctp --enable-debug",
 			            "make",
 			            "make install",
 			            "ldconfig",


### PR DESCRIPTION
-Add -R to client for raw output
-A little more robust handling of client exit: wait
 for client duration, then kill it if it's still running,
 and "kill it good" if it keeps running after that.
-We seems to have a number of problems with the client:
 sometimes it exits with error when it should not, and
 sometime it never exits.  So, this work is not over.