### PR TITLE
UPERF : enable uperf CRR (connection-per-second) profile

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -18,6 +18,7 @@ remotehost=""
 control_port=""
 data_port=""
 test_type="stream"
+uopts=""
 
 longopts="test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
@@ -132,6 +133,10 @@ if [ -z "$data_port" ]; then
     let "data_port = $control_port + 1"
     echo "data_port was not set, using default of $data_port"
 fi
+if [[ "$test_type" = "crr" ]]; then
+    # show more details of connect/disconnect
+    uopts="-tTfa"
+fi
 /bin/cp /tmp/xml-files/$test_type.xml test.xml
 echo "remotehost=$remotehost"
 echo "control_port=$control_port"
@@ -149,7 +154,7 @@ duration=$duration \
 wsize=$wsize \
 rsize=$rsize \
 port=$data_port \
-uperf -R -m test.xml -P $control_port 2>&1 >uperf-client-result.txt
+uperf -R -m test.xml -P $control_port $uopts 2>&1 >uperf-client-result.txt
 uperf_rc=$?
 if [ $uperf_rc -gt 0 ]; then
     uperf_errors=`grep -i error uperf-client-result.txt`

--- a/uperf-post-process
+++ b/uperf-post-process
@@ -41,7 +41,7 @@ if (! defined $test_type) {
 }
 
 my $primary_metric;
-if ($test_type eq "rr" or $test_type eq "ping-pong") {
+if ($test_type eq "rr" or $test_type eq "ping-pong" or $test_type eq "crr") {
     $primary_metric = 'transactions-sec';
 } else {
     $primary_metric = 'Gbps';
@@ -53,19 +53,19 @@ if ($rc == 0 and defined $fh) {
     my $ts, my $prev_ts, my $bytes, my $prev_bytes, my $ops, my $prev_ops;;
     my %names = ();
     while (<$fh>) {
-        if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
-            $ts = $1, $bytes = $2, $ops = $3;
-            if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
-                {
-                    my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'Gbps');
-                    my %names = ('cmd' => 'readandwrite');
-                    my %s = ('end' => int $ts,
-                            'value' =>  8.0 * ($bytes - $prev_bytes) / 1000000000 / $ts_diff);
-                    log_sample("0", \%desc, \%names, \%s);
-                }
-                if ($test_type eq "rr" or $test_type eq "ping-pong") {
-                    # RR transactions are two operations
-                    my $tps = ($ops - $prev_ops) / $ts_diff / 2;
+        if ( $test_type eq "crr") {
+            if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn1\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
+                $ts = $1, $bytes = $2, $ops = $3;
+                if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
+                    {
+                        my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'Gbps');
+                        my %names = ('cmd' => 'readandwrite');
+                        my %s = ('end' => int $ts,
+                                'value' =>  8.0 * ($bytes - $prev_bytes) / 1000000000 / $ts_diff);
+                        log_sample("0", \%desc, \%names, \%s);
+                    }
+                    # CPS transactions are four operations
+                    my $tps = ($ops - $prev_ops) / $ts_diff / 4;
                     {
                         my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'transactions-sec');
                         my %s = ('end' => int $ts, 'value' => 0.0 + $tps);
@@ -77,10 +77,40 @@ if ($rc == 0 and defined $fh) {
                         log_sample("0", \%desc, \%names, \%s);
                     }
                 }
+                $prev_ts = $ts;
+                $prev_bytes = $bytes;
+                $prev_ops = $ops;
             }
-            $prev_ts = $ts;
-            $prev_bytes = $bytes;
-            $prev_ops = $ops;
+        } else {
+            if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
+                $ts = $1, $bytes = $2, $ops = $3;
+                if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
+                    {
+                        my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'Gbps');
+                        my %names = ('cmd' => 'readandwrite');
+                        my %s = ('end' => int $ts,
+                                'value' =>  8.0 * ($bytes - $prev_bytes) / 1000000000 / $ts_diff);
+                        log_sample("0", \%desc, \%names, \%s);
+                    }
+                    if ($test_type eq "rr" or $test_type eq "ping-pong" ) {
+                        # RR transactions are two operations
+                        my $tps = ($ops - $prev_ops) / $ts_diff / 2;
+                        {
+                            my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'transactions-sec');
+                            my %s = ('end' => int $ts, 'value' => 0.0 + $tps);
+                            log_sample("0", \%desc, \%names, \%s);
+                        }
+                        if ($tps > 0) {
+                            my %desc = ('source' => 'uperf', 'class' => 'count', 'type' => 'round-trip-usec');
+                            my %s = ('end' => int $ts, 'value' => 0.0 + $nthreads / $tps *1000000);
+                            log_sample("0", \%desc, \%names, \%s);
+                        }
+                    }
+                }
+                $prev_ts = $ts;
+                $prev_bytes = $bytes;
+                $prev_ops = $ops;
+            }
         }
     }
     close($fh);

--- a/workshop.json
+++ b/workshop.json
@@ -23,7 +23,7 @@
 		            "unpack": "tar -xzf 1.0.7.tar.gz",
 		            "get_dir": "tar -tzf 1.0.7.tar.gz | head -n 1",
 		            "commands": [
-			            "CFLAGS=\"-ggdb\" ./configure --disable-sctp --enable-debug",
+			            "CFLAGS=\"-ggdb\" ./configure --disable-sctp",
 			            "make",
 			            "make install",
 			            "ldconfig",

--- a/xml-files/crr.xml
+++ b/xml-files/crr.xml
@@ -2,7 +2,7 @@
 <profile name="connect-request-response">
   <group nthreads="$nthreads">
     <transaction duration="$duration">
-      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol"/>
+      <flowop type="connect" options="remotehost=$remotehost protocol=$protocol port=$port"/>
       <flowop type="write" options="size=$wsize"/>
       <flowop type="read"  options="size=$rsize"/>
       <flowop type="disconnect"/>


### PR DESCRIPTION
Description: 
============
The Connection-per-Second (CPS) benchmark exercises <connect/write/read/close> sequences. The write and read typically involve small payloads that fit into a single frame.

Solution:
=======
- Create a new UPERF profile. 
- Add post processing for the new result.

File Changes:
========
- uperf-client: enable flags "tTfa" to show more detailed stats of connect, disconnect ops
- uperf-post-process: add logic to process "Txn1", the cps records. 
- workshop.json: remove compiler "--enable-debug" - This flag generates a debug message for each connect and disconnect op.  For crr, the cps might be limited by the printf rate.
- crr.xml: add "port" params per current uperf. 

Test:
====
A condensed run results is as follows:

tags: irq=bal kernel=4.18.0-305.19.1.rt7.91.el8_4.x86_64 mtu=8950 osruntime=chroot pods-per-worker=1 rcos=48.84.202109210859-0 scale_out_factor=1 sdn=OpenShiftSDN topo=egress userenv=stream
    common params: duration=120 ifname=ens8f1 protocol=tcp rsize=4096 test-type=crr wsize=512
      unique params: nthreads=1
          primary period-id: BC30B440-428E-11EC-B59E-D8A355174252
          primary period-id: BEAAC94A-428E-11EC-B59E-D8A355174252
          primary period-id: BAE7094A-428E-11EC-B59E-D8A355174252
        result: (transactions-sec) samples: 6342.00 6376.00 6376.00 mean: 6364.67 min: 6342.00 max: 6376.00 stddev: 19.63 stddevpct: 0.31
      unique params: nthreads=16
          primary period-id: C4D458CC-428E-11EC-B59E-D8A355174252
          primary period-id: C25ACD1A-428E-11EC-B59E-D8A355174252
          primary period-id: C74D2106-428E-11EC-B59E-D8A355174252
        result: (transactions-sec) samples: 22510.00 22750.00 23300.00 mean: 22853.33 min: 22510.00 max: 23300.00 stddev: 405.01 stddevpct: 1.77
~                                                                                                                                                                                                                                                                                                                      
~                                                                                                                                                         
