### PR TITLE
handle future rickshaw changes to roadblock names

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -107,7 +107,10 @@ if [ -z "$remotehost" ]; then
     echo "--remotehost was not set via cmdline args, checking any messages from the endpoint"
     echo "These files exist in ./msgs/rx:"
     /bin/ls -l msgs/rx
-    file="msgs/rx/client-start:1"
+    file="msgs/rx/server-start-end:1"
+    if [ ! -e "${file}" ]; then
+	file="msgs/rx/client-start:1"
+    fi
     if [ -e "$file" ]; then
         echo "Found $file"
         ipaddr=`jq -r '.svc.ip' $file`


### PR DESCRIPTION
- with rickshaw roadblock names changing the files where messages sent
  between the client and server are changing names

- this code is a bridge between the old style and the new style,
  eventually the support for the old style can be removed