### PR TITLE
handle the service message coming from one of three different roadblo…

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -107,9 +107,16 @@ if [ -z "$remotehost" ]; then
     echo "--remotehost was not set via cmdline args, checking any messages from the endpoint"
     echo "These files exist in ./msgs/rx:"
     /bin/ls -l msgs/rx
-    file="msgs/rx/server-start-end:1"
+    file="msgs/rx/endpoint-start-end:1"
     if [ ! -e "${file}" ]; then
+	echo -n "Did not fine ${file}"
+	file="msgs/rx/server-start-end:1"
+	echo ", trying ${file}"
+    fi
+    if [ ! -e "${file}" ]; then
+	echo -n "Did not find ${file}"
 	file="msgs/rx/client-start:1"
+	echo ", trying ${file}"
     fi
     if [ -e "$file" ]; then
         echo "Found $file"


### PR DESCRIPTION
…ck names

- 'endpoint-start-end' is for messages from the endpoint (ie. k8s
  after a service configuration)

- 'server-start-end' is for messages from conventional client/server
  endpoint runs (ie. remotehost)

- 'client-start' is for backwards compatibility with pre-rickshaw
  rewrite