### PR TITLE
correct job failure behavior

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -51,8 +51,8 @@ jobs:
     needs:
     - generate-job-matrix-parameters
     - display-job-matrix-parameters
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         endpoint: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.endpoints_github) }}
         userenv: ${{ fromJSON(needs.generate-job-matrix-parameters.outputs.userenvs) }}


### PR DESCRIPTION
- do not continue processing workflow jobs when one fails

- do let all strategy jobs run to completion even if one (or more) fails (I think we want to always see the result of all strategy jobs)