### PR TITLE
Updates to CRR test

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -27,7 +27,7 @@
         "positive_float": {
             "description": "a floating point number greater than 0",
             "args": [ "think" ],
-            "vals": "[0-9*\\.[0-9]*"
+            "vals": "[0-9*]\\.[0-9]*"
         },
         "host-or-ip": {
             "description" : "a hostname or IP address",

--- a/multiplex.json
+++ b/multiplex.json
@@ -27,7 +27,7 @@
         "positive_float": {
             "description": "a floating point number greater than 0",
             "args": [ "think" ],
-            "vals": "[0-9*]\\.[0-9]*"
+            "vals": "[0-9]*\\.[0-9]*"
         },
         "host-or-ip": {
             "description" : "a hostname or IP address",

--- a/multiplex.json
+++ b/multiplex.json
@@ -24,6 +24,11 @@
             "args": [ "wsize", "rsize", "nthreads", "duration" ],
             "vals": "[1-9][0-9]*"
         },
+        "positive_float": {
+            "description": "a floating point number greater than 0",
+            "args": [ "think" ],
+            "vals": "[0-9*\\.[0-9]*"
+        },
         "host-or-ip": {
             "description" : "a hostname or IP address",
             "args": [ "remotehost" ],

--- a/uperf-client
+++ b/uperf-client
@@ -13,6 +13,7 @@ nthreads=1
 protocol="tcp"
 wsize=1024
 rsize=1024
+think=0.001 # time in seconds
 duration=60
 remotehost=""
 control_port=""
@@ -21,7 +22,7 @@ test_type="stream"
 uopts=""
 cpu_pin=""
 
-longopts="test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:,cpu-pin:"
+longopts="test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:,cpu-pin:,think:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error "Unrecognized option specified"
@@ -66,6 +67,12 @@ while true; do
             shift;
             wsize=$1
             echo "wsize=$wsize"
+            shift
+            ;;
+        --think)
+            shift;
+            think=$1
+            echo "think=$think"
             shift
             ;;
         --remotehost)
@@ -206,6 +213,7 @@ remotehost=$remotehost \
 duration=$duration \
 wsize=$wsize \
 rsize=$rsize \
+think=$think \
 port=$data_port \
 ${cmd} > uperf-client-result.txt 2>&1
 uperf_rc=$?

--- a/uperf-client
+++ b/uperf-client
@@ -195,6 +195,7 @@ echo "data_port=$data_port"
 echo "duration=$duration"
 echo "wsize=$wsize"
 echo "rsize=$rsize"
+echo "think=$think"
 echo "nthreads=$nthreads"
 echo "protocol=$protocol"
 

--- a/uperf-post-process
+++ b/uperf-post-process
@@ -30,6 +30,7 @@ GetOptions ("test-type=s" => \$test_type,
             "remotehost=s" => \$remotehost,
             "wsize=i" => \$ignore,
             "rsize=i" => \$ignore,
+            "think=f" => \$ignore,
             "protocol=s" => \$ignore,
             "duration=i" => \$ignore,
             "ifname=s" => \$ignore,
@@ -42,8 +43,10 @@ if (! defined $test_type) {
 }
 
 my $primary_metric;
-if ($test_type eq "rr" or $test_type eq "ping-pong" or $test_type eq "crr") {
+if ($test_type eq "rr" or $test_type eq "ping-pong") {
     $primary_metric = 'transactions-sec';
+} elsif ($test_type eq "crr") {
+    $primary_metric = 'connections-sec';
 } else {
     $primary_metric = 'Gbps';
 }
@@ -65,16 +68,16 @@ if ($rc == 0 and defined $fh) {
                                 'value' =>  8.0 * ($bytes - $prev_bytes) / 1000000000 / $ts_diff);
                         log_sample("0", \%desc, \%names, \%s);
                     }
-                    # CPS transactions are four operations
-                    my $tps = ($ops - $prev_ops) / $ts_diff / 4;
+                    # CPS transactions are five operations: connect, write, think, read, disconnect
+                    my $cps = ($ops - $prev_ops) / $ts_diff / 5;
                     {
-                        my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'transactions-sec');
-                        my %s = ('end' => int $ts, 'value' => 0.0 + $tps);
+                        my %desc = ('source' => 'uperf', 'class' => 'throughput', 'type' => 'connections-sec');
+                        my %s = ('end' => int $ts, 'value' => 0.0 + $cps);
                         log_sample("0", \%desc, \%names, \%s);
                     }
-                    if ($tps > 0) {
+                    if ($cps > 0) {
                         my %desc = ('source' => 'uperf', 'class' => 'count', 'type' => 'round-trip-usec');
-                        my %s = ('end' => int $ts, 'value' => 0.0 + $nthreads / $tps *1000000);
+                        my %s = ('end' => int $ts, 'value' => 0.0 + $nthreads / $cps *1000000);
                         log_sample("0", \%desc, \%names, \%s);
                     }
                 }
@@ -125,6 +128,7 @@ if ($rc == 0 and defined $fh) {
     $period{'metric-files'} = \@metric_files;
     push(@periods, \%period);
     $sample{'periods'} = \@periods;
+    $sample{'benchmark'} = 'uperf';
     $sample{'primary-period'} = 'measurement';
     $sample{'primary-metric'} = $primary_metric;
     $rc = put_json_file("post-process-data.json", \%sample);

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -34,7 +34,7 @@ while true; do
             echo "ifname=$ifname"
             shift
             ;;
-        --test-type|--nthreads|--protocol|--rsize|--wsize|--remotehost|--duration)
+        --test-type|--nthreads|--protocol|--rsize|--wsize|--remotehost|--duration|--think)
             shift;
             shift;
             ;;

--- a/xml-files/README-crr.md
+++ b/xml-files/README-crr.md
@@ -1,0 +1,2 @@
+# crr.xml
+The crr test may exhaust client-side port numbers, due to TCP close_time_wait, which keeps TCP connections around for 60 seconds.  Due to this situation, we recommend not exceeding ~800 connections per second, per client.  To drive a server at a higher connection rate, use multiple clients (with different IP addresses) to multiple servers (on same host with same IP address).

--- a/xml-files/crr.xml
+++ b/xml-files/crr.xml
@@ -4,6 +4,7 @@
     <transaction duration="$duration">
       <flowop type="connect" options="remotehost=$remotehost protocol=$protocol port=$port"/>
       <flowop type="write" options="size=$wsize"/>
+      <flowop type="think" options="duration=$think"/>
       <flowop type="read"  options="size=$rsize"/>
       <flowop type="disconnect"/>
     </transaction>


### PR DESCRIPTION
- Add think time in seconds, to help throttle connections/sec as to not saturate all source ports.
- Add connections-sec to differntiate the metric for CRR from RR test
- Add 'benchmark' field to post-process-data.json file (needed for multi-benchmark)