### PR TITLE
revert uperf version upgrade from 1.0.7 to 1.0.8

### DIFF
--- a/workshop.json
+++ b/workshop.json
@@ -17,13 +17,12 @@
 	        "name": "uperf_src",
 	        "type": "source",
 	        "source_info": {
-		        "url": "https://github.com/uperf/uperf/archive/refs/tags/v1.0.8.tar.gz",
-		        "filename": "uperf_src.tar.gz",
+		        "url": "https://github.com/uperf/uperf/archive/1.0.7.tar.gz",
+		        "filename": "1.0.7.tar.gz",
 		        "commands": { 
-		            "unpack": "tar -xzf uperf_src.tar.gz",
-		            "get_dir": "tar -tzf uperf_src.tar.gz | head -n 1",
+		            "unpack": "tar -xzf 1.0.7.tar.gz",
+		            "get_dir": "tar -tzf 1.0.7.tar.gz | head -n 1",
 		            "commands": [
-			            "autoreconf --install",
 			            "CFLAGS=\"-ggdb\" ./configure --disable-sctp",
 			            "make",
 			            "make install",


### PR DESCRIPTION
- version 1.0.8 is not building in all environments, need to resolve this before adopting it

- a quirk/error/bug in the branch protection rules allowed this patch to be merged despite failing CI