### PR TITLE
Graceful error handling of mv-param "cpu-pin": "numa" when PCIe has no numa

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -162,7 +162,9 @@ ifname_numa_node=-1
 ifname_numa_node_cpus=-1
 if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
     ifname_numa_node=$(cat /sys/class/net/${ifname}/device/numa_node)
-
+    if [ $ifname_numa_node == "-1" ] && [ "${cpu_pin}" == "numa" ]; then
+        exit_error "PCIe has no NUMA locality, but cpu-pin is numa"
+    fi
     ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
 elif [ "${cpu_pin}" == "numa" ]; then
     exit_error "cannot determine numa node for interface '${ifname}' and cpu-pin is numa"

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -147,7 +147,9 @@ ifname_numa_node=-1
 ifname_numa_node_cpus=-1
 if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
     ifname_numa_node=$(cat /sys/class/net/${ifname}/device/numa_node)
-
+    if [ $ifname_numa_node == "-1" ] && [ "${cpu_pin}" == "numa" ]; then
+        exit_error "PCIe has no NUMA locality, but cpu-pin is numa"
+    fi
     ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
 elif [ "${cpu_pin}" == "numa" ]; then
     exit_error "cannot determine numa node for interface '${ifname}' and cpu-pin is numa"


### PR DESCRIPTION
This happened on Bill M's AMD machine when BIOS setting to 1 NUMA.  W/o this error check, the cpu_list is ":-1" leading to later failure at "taskset --cpu_list :-1"