### PR TITLE
Add uperf throughput-delta-pct stats to detect UDP drops

### DIFF
--- a/uperf-post-process
+++ b/uperf-post-process
@@ -54,7 +54,7 @@ my $result_file = "uperf-client-result.txt";
 my %desc = ('source' => 'uperf', 'class' => 'throughput');
 (my $rc, my $fh) = open_read_text_file($result_file);
 if ($rc == 0 and defined $fh) {
-    my $ts, my $prev_ts, my $bytes, my $prev_bytes, my $ops, my $prev_ops;;
+    my $ts, my $prev_ts, my $start_ts, my $bytes, my $prev_bytes, my $ops, my $prev_ops;;
     my %names = ();
     while (<$fh>) {
         if ( $test_type eq "crr") {
@@ -86,6 +86,16 @@ if ($rc == 0 and defined $fh) {
                 $prev_ops = $ops;
             }
         } else {
+            # Extract % stats from lines                  Time       Data     Throughput   Operations      Errors
+            #                          "Difference(%)     -0.99%     52.34%       52.81%       52.34%       0.00% "
+
+            if ( /^Difference\(%\) \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)%/   ) {
+                my $Tput_val = $3;
+                my %desc = ('source' => 'uperf', 'class' => 'count', 'type' => 'throughput-delta-pct');
+                my %s = ('begin' => int $start_ts, 'end' => int $ts, 'value' => $Tput_val);
+                log_sample("0", \%desc, \%names, \%s);
+            }
+
             if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
                 $ts = $1, $bytes = $2, $ops = $3;
                 if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
@@ -110,6 +120,8 @@ if ($rc == 0 and defined $fh) {
                             log_sample("0", \%desc, \%names, \%s);
                         }
                     }
+                } else {
+                    $start_ts = $ts;
                 }
                 $prev_ts = $ts;
                 $prev_bytes = $bytes;


### PR DESCRIPTION
**Problem description:**
In UPERF stream, the primary metric is the Gbps , the time-series of Tx byte counts.  When UDP, viewing Gbps alone we do not see packet loss, and therefore may miss the picture.


```
timestamp_ms:1701713174720.9150 name:Txn3 nr_bytes:0 nr_ops:110
-------------------------------------------------------------------------------
timestamp_ms:1701713174720.9255 name:Total nr_bytes:919244111872 nr_ops:1795398830
Netstat statistics for this run
-------------------------------------------------------------------------------
Nic       opkts/s     ipkts/s      obits/s      ibits/s
eth0     13951267           0    60.27Gb/s     28.25b/s
-------------------------------------------------------------------------------
Run Statistics
Hostname            Time       Data   Throughput   Operations      Errors
-------------------------------------------------------------------------------
10.131.0.220     122.32s    92.84GB     6.52Gb/s    194709184        0.00
master           122.32s   856.11GB    60.12Gb/s   1795398848        0.00
-------------------------------------------------------------------------------
Difference(%)     -0.00%     89.16%       89.16%      89.16%       0.00%  
```

**Solution:**
Collect the Throughput difference metric, and index them.


 