### PR TITLE
Add uperf throughput-delta-pct stats to detect UDP drops

### DIFF
--- a/uperf-post-process
+++ b/uperf-post-process
@@ -54,7 +54,7 @@ my $result_file = "uperf-client-result.txt";
 my %desc = ('source' => 'uperf', 'class' => 'throughput');
 (my $rc, my $fh) = open_read_text_file($result_file);
 if ($rc == 0 and defined $fh) {
-    my $ts, my $prev_ts, my $bytes, my $prev_bytes, my $ops, my $prev_ops;;
+    my $ts, my $prev_ts, my $start_ts, my $bytes, my $prev_bytes, my $ops, my $prev_ops;;
     my %names = ();
     while (<$fh>) {
         if ( $test_type eq "crr") {
@@ -86,6 +86,16 @@ if ($rc == 0 and defined $fh) {
                 $prev_ops = $ops;
             }
         } else {
+            # Extract % stats from lines                  Time       Data     Throughput   Operations      Errors
+            #                          "Difference(%)     -0.99%     52.34%       52.81%       52.34%       0.00% "
+
+            if ( /^Difference\(%\) \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)% \s+(-?\d+\.\d+)%/   ) {
+                my $Tput_val = $3;
+                my %desc = ('source' => 'uperf', 'class' => 'count', 'type' => 'throughput-delta-pct');
+                my %s = ('begin' => int $start_ts, 'end' => int $ts, 'value' => $Tput_val);
+                log_sample("0", \%desc, \%names, \%s);
+            }
+
             if ( /^timestamp_ms:(\d+)\.\d+\s+name:Txn2\s+nr_bytes:(\d+)\s+nr_ops:(\d+)/ ) {
                 $ts = $1, $bytes = $2, $ops = $3;
                 if (defined $prev_ts and ((my $ts_diff = ($ts - $prev_ts) / 1000) > 0)) {
@@ -110,6 +120,8 @@ if ($rc == 0 and defined $fh) {
                             log_sample("0", \%desc, \%names, \%s);
                         }
                     }
+                } else {
+                    $start_ts = $ts;
                 }
                 $prev_ts = $ts;
                 $prev_bytes = $bytes;


### PR DESCRIPTION
**Problem description:**
In UPERF stream, the primary metric is the Gbps , the time-series of Tx byte counts. When UDP, viewing Gbps alone we do not see packet loss, and therefore may miss the picture.
```
..
timestamp_ms:1706563005688.6326 name:Total nr_bytes:43134222311 nr_ops:1316378
Netstat statistics for this run
-------------------------------------------------------------------------------
Nic       opkts/s     ipkts/s      obits/s      ibits/s
eth0        58059       15497    28.06Gb/s     8.18Mb/s
-------------------------------------------------------------------------------
Run Statistics
Hostname            Time       Data   Throughput   Operations      Errors
-------------------------------------------------------------------------------
10.130.2.129      12.31s    40.16GB    28.02Gb/s      1316099        0.00
master            12.31s    40.17GB    28.03Gb/s      1316380        0.00
-------------------------------------------------------------------------------
Difference(%)     -0.00%      0.02%        0.02%        0.02%       0.00%

```
**Solution:**
Collect the Throughput difference metric, and index them.

**Test**
The content of the metric-data-0.csv
```
0,1706562995378,1706562996379,36.671877
0,1706562996380,1706562997380,36.135542
0,1706562997381,1706562998381,35.934417
0,1706562998382,1706562999382,36.336668
0,1706562999383,1706563000383,36.068500
0,1706563000384,1706563001384,35.666249
0,1706563001385,1706563002385,31.576698
0,1706563002386,1706563003386,32.314158
0,1706563003387,1706563004387,32.113033
0,1706563004388,1706563005588,26.597684
1,1706562995378,1706563005588,0.020000    <==== the new type, idx=1 with the correct start and end
```
                                              `

