### PR TITLE
Graceful error handling of when PCIe has no numa and mv-params has "cpu_pin" option

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -162,7 +162,9 @@ ifname_numa_node=-1
 ifname_numa_node_cpus=-1
 if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
     ifname_numa_node=$(cat /sys/class/net/${ifname}/device/numa_node)
-
+    if [ $ifname_numa_node == "-1" ] && [ "${cpu_pin}" == "numa" ]; then
+        exit_error "PCIe has no NUMA locality, but cpu-pin is numa"
+    fi
     ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
 elif [ "${cpu_pin}" == "numa" ]; then
     exit_error "cannot determine numa node for interface '${ifname}' and cpu-pin is numa"

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -147,7 +147,9 @@ ifname_numa_node=-1
 ifname_numa_node_cpus=-1
 if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
     ifname_numa_node=$(cat /sys/class/net/${ifname}/device/numa_node)
-
+    if [ $ifname_numa_node == "-1" ] && [ "${cpu_pin}" == "numa" ]; then
+        exit_error "PCIe has no NUMA locality, but cpu-pin is numa"
+    fi
     ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
 elif [ "${cpu_pin}" == "numa" ]; then
     exit_error "cannot determine numa node for interface '${ifname}' and cpu-pin is numa"


### PR DESCRIPTION
**Problem:** 
For some system, e.g AMD, we can define 0, 1, 2 or 4 NUMA nodes per socket.  In the case that was 0 (whole flat memory layout for both sockets), "cat /sys/class/net/ens2f0np0/device/numa_node" returns "-1" . This is the normal behavior per https://access.redhat.com/discussions/4490711.

Now if the uperf  CLI  has the "cpu_pin" option to indicate pinning CPUs to same numa as the NIC in-use, the subsequent code ends up blindly invoked "taskset --cpu_list  -1"
**Solution:**
Add a snippet to detect  cpu_list = -1 and uperf  CLI has "cpu_pin", and error out the run gracefully. The user must remove the "cpu_pin" option from the mv-params when running on host w/o NUMA.
