### PR TITLE
Add  "passthru" CLI argument

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -39,6 +39,11 @@
 	    "args": [ "ifname" ],
 	    "vals": "^.+$"
 	},
+	"passthru": {
+	    "description": "comma separated list",
+	    "args": [ "passthru" ],
+	    "vals": "^.+$"
+    },
 	"cpu-pinning": {
 	    "description": "valid cpu pinning modes",
 	    "args": [ "cpu-pin" ],

--- a/uperf-client
+++ b/uperf-client
@@ -22,7 +22,7 @@ test_type="stream"
 uopts=""
 cpu_pin=""
 
-longopts="test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:,cpu-pin:,think:"
+longopts="test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:,cpu-pin:,think:,passthru:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error "Unrecognized option specified"
@@ -85,6 +85,12 @@ while true; do
             shift;
             duration=$1
             echo "duration=$duration"
+            shift
+            ;;
+        --passthru)     # uperf options that user wants passthru
+            shift;
+            pt_opts=$1
+            echo "pt_opts=$pt_opts"
             shift
             ;;
         --)
@@ -209,6 +215,13 @@ case "${cpu_pin}" in
 esac
 
 cmd+="${cpu_pin_cmd} uperf -R -m test.xml -P $control_port $uopts"
+
+# strip ',' from the passthru options 
+passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
+options+=" $passthru_opts"
+echo "passthu options: $options"
+cmd+="$options"
+
 echo "going to run: ${cmd}"
 nthreads=$nthreads \
 protocol=$protocol \

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -14,7 +14,7 @@ data_port=""
 ifname=""
 cpu_pin=""
 
-longopts="ifname:,cpu-pin:"
+longopts="ifname:,cpu-pin:,passthru:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error  "Unrecognized option specified"
@@ -37,6 +37,12 @@ while true; do
         --test-type|--nthreads|--protocol|--rsize|--wsize|--remotehost|--duration|--think)
             shift;
             shift;
+            ;;
+        --passthru)     # uperf options that user wants passthru
+            shift;
+            pt_opts=$1
+            echo "pt_opts=$pt_opts"
+            shift
             ;;
         --)
             shift;
@@ -166,6 +172,14 @@ case "${cpu_pin}" in
 esac
 
 cmd="${cpu_pin_cmd} uperf -s -P $control_port"
+
+# strip ',' from the passthru options 
+passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
+options+=" $passthru_opts"
+echo "passthu optins run: $options"
+
+cmd+="$options"
+
 echo "going to run: $cmd"
 export MALLOC_CHECK_=2
 $cmd 2>&1 >uperf-server-start.txt &


### PR DESCRIPTION
A passthru CLI options allows quick [experiments](https://github.com/HughNhan/IPsecTest) with other fancier uperf  options i.e. custom uperf with -B option to support tunnel interface binding.