### PR TITLE
Add IPv6 support

### DIFF
--- a/multiplex.json
+++ b/multiplex.json
@@ -19,6 +19,11 @@
             "args": [ "protocol" ],
             "vals": "^tcp$|^udp$"
         },
+        "ipv": {
+            "description": "ipv4 or ipv6",
+            "args": [ "ipv" ],
+            "vals": "^4$|^6$"
+        },
         "positive_integer": {
             "description": "a whole number greater than 0",
             "args": [ "wsize", "rsize", "nthreads", "duration" ],

--- a/uperf-client
+++ b/uperf-client
@@ -21,8 +21,9 @@ data_port=""
 test_type="stream"
 uopts=""
 cpu_pin=""
+ipv="4"
 
-longopts="test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:,cpu-pin:,think:,passthru:"
+longopts="ipv:,test-type:,protocol:,rsize:,wsize:,nthreads:,remotehost:,duration:,cpu-pin:,think:,passthru:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error "Unrecognized option specified"
@@ -30,12 +31,18 @@ fi
 eval set -- "$opts";
 while true; do
     case "$1" in
-	--cpu-pin)
-	    shift;
-	    cpu_pin=$1
-	    echo "cpu_pin=${cpu_pin}"
-	    shift;
-	    ;;
+        --ipv)
+            shift;
+            ipv="$1"
+            echo "ipv=$ipv"
+            shift
+            ;;
+        --cpu-pin)
+            shift;
+            cpu_pin=$1
+            echo "cpu_pin=${cpu_pin}"
+            shift;
+            ;;
         --test-type)
             shift;
             test_type=$1

--- a/uperf-post-process
+++ b/uperf-post-process
@@ -35,6 +35,7 @@ GetOptions ("test-type=s" => \$test_type,
             "duration=i" => \$ignore,
             "ifname=s" => \$ignore,
             "cpu-pin=s" => \$ignore,
+            "ipv=i" => \$ignore,
             );
 
 if (! defined $test_type) {

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -13,8 +13,9 @@ control_port=""
 data_port=""
 ifname=""
 cpu_pin=""
+ipv="4"
 
-longopts="ifname:,cpu-pin:,passthru:"
+longopts="ipv:,ifname:,cpu-pin:,passthru:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error  "Unrecognized option specified"
@@ -22,12 +23,18 @@ fi
 eval set -- "$opts";
 while true; do
     case "$1" in
-	--cpu-pin)
-	    shift;
-	    cpu_pin=$1
-	    echo "cpu_pin=${cpu_pin}"
-	    shift;
-	    ;;
+        --cpu-pin)
+            shift;
+            cpu_pin=$1
+            echo "cpu_pin=${cpu_pin}"
+            shift;
+            ;;
+        --ipv)
+            shift;
+            ipv=$1
+            echo "ipv=${ipv}"
+            shift;
+            ;;
         --ifname)
             shift;
             ifname="$1"
@@ -91,32 +98,51 @@ if [ ! -z "$ifname" ]; then
         ifname="${before_var}${var}${after_var}"
     fi
     if [ "${ifname}" == "default-route" ]; then
-	echo "Looking for default route interface..."
-	ip -j route > route.json
-	ifname=$(jq --raw-output 'to_entries | .[] | if (.value.dst == "default") then .value.dev else null end' route.json | grep -v null)
-	if [ -z "${ifname}" ]; then
-	    exit_error "could not find default route interface"
-	else
-	    echo "Found default route on interface ${ifname}"
-	fi
+       echo "Looking for default route interface..."
+       ip -j route > route.json
+       ifname=$(jq --raw-output 'to_entries | .[] | if (.value.dst == "default") then .value.dev else null end' route.json | grep -v null)
+       if [ -z "${ifname}" ]; then
+           exit_error "could not find default route interface"
+       else
+           echo "Found default route on interface ${ifname}"
+       fi
     else
-	echo "--ifname=$ifname was found"
+       echo "--ifname=${ifname} was found"
     fi
     echo "Searching for IP for interface ${ifname}..."
+
+    echo "--ifname=$ifname was found, searching for IP"
     # Find the element in the 'ip a' array that matches the ifname we are looking for
     ifname_idx=`jq 'to_entries | .[] | if (.value.ifname == "'$ifname'") then .key else null end' ip.json | grep -v null`
     if [ ! -z "$ifname_idx" ]; then
-        echo "$ifname matches index $ifname_idx, looking for ipv4 (inet) in addr_info:"
-        jq '.['$ifname_idx'].addr_info' ip.json
-        # Find the first ipv4 address
-        addr_idx=`jq '.['$ifname_idx'].addr_info | to_entries | .[] | if (.value.family == "inet") then .key else null end' ip.json | grep -v null | head -1`
-        if [ ! -z $addr_idx ]; then
-            echo "Found inet in index $addr_idx:"
-            jq -r '.['$ifname_idx'].addr_info['$addr_idx']' ip.json
-            ip=`jq -r '.['$ifname_idx'].addr_info['$addr_idx'].local' ip.json`
+        if [ "$ipv" == "4" ]; then
+            echo "$ifname matches index $ifname_idx, looking for ipv4 (inet) in addr_info:"
+            jq '.['$ifname_idx'].addr_info' ip.json
+            # Find the first ipv4 address
+            addr_idx=`jq '.['$ifname_idx'].addr_info | to_entries | .[] | if (.value.family == "inet") then .key else null end' ip.json | grep -v null | head -1`
+            if [ ! -z $addr_idx ]; then
+                echo "Found inet in index $addr_idx:"
+                jq -r '.['$ifname_idx'].addr_info['$addr_idx']' ip.json
+                ip=`jq -r '.['$ifname_idx'].addr_info['$addr_idx'].local' ip.json`
+            else
+                addr_info=`jq '.['$ifname_idx'].addr_info' ip.json`
+                exit_error "An IPV4 address could not be found for $ifname in addr_info: $addr_info"
+            fi
+        elif [ "$ipv" == "6" ]; then
+            echo "$ifname matches index $ifname_idx, looking for ipv6 (inet6) in addr_info:"
+            jq '.['$ifname_idx'].addr_info' ip.json
+            # Find the first ipv4 address
+            addr_idx=`jq '.['$ifname_idx'].addr_info | to_entries | .[] | if (.value.family == "inet6") then .key else null end' ip.json | grep -v null | head -1`
+            if [ ! -z $addr_idx ]; then
+                echo "Found inet in index $addr_idx:"
+                jq -r '.['$ifname_idx'].addr_info['$addr_idx']' ip.json
+                ip=`jq -r '.['$ifname_idx'].addr_info['$addr_idx'].local' ip.json`
+            else
+                addr_info=`jq '.['$ifname_idx'].addr_info' ip.json`
+                exit_error "An IPV6 address could not be found for $ifname in addr_info: $addr_info"
+            fi
         else
-            addr_info=`jq '.['$ifname_idx'].addr_info' ip.json`
-            exit_error "An IPV4 address could not be found for $ifname in addr_info: $addr_info"
+            exit_error "The value for --ipv, $ipv, is not supported.  Use 4 for ipv4 or 6 for ipv6"
         fi
     else
         interfaces=`jq -r '. | to_entries | .[] | .value.ifname' ip.json`
@@ -184,7 +210,7 @@ cmd="${cpu_pin_cmd} uperf -s -P $control_port"
 # strip ',' from the passthru options 
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
 options+=" $passthru_opts"
-echo "passthu optins run: $options"
+echo "passthu options: $options"
 
 cmd+="$options"
 


### PR DESCRIPTION
Description: add ipv6 option

Implementation: leverage bench-iperf code

Test:  Verified both ipv4 and ipv6 work.

```
      unique params: ipv=6  <==========================  verified server address is IPv6
      primary-period name: measurement
      samples:
        sample-id: 3F69AAE4-31C2-11F0-86FF-9E75C6AF313F
          primary period-id: 3F6A0A52-31C2-11F0-90C2-B8147CCB9632
          period range: begin: 1747336868030 end: 1747336878242
          period length: 10.212 seconds
            result: (uperf::Gbps) samples: 23.913798 mean: 23.913798 min: 23.913798 max: 23.913798 stddev: NaN stddevpct: NaN
    iteration-id: 28B1E190-31C2-11F0-BD4C-814B8065B7CB
      unique params: ipv=4  <===========================  verified server address is IPv4
      primary-period name: measurement
      samples:
        sample-id: 3F6E8AD2-31C2-11F0-84CC-ECB9351D9F41
          primary period-id: 3F6ED3C0-31C2-11F0-B242-F13D0E505C29
          period range: begin: 1747336958902 end: 1747336969112
          period length: 10.21 seconds
            result: (uperf::Gbps) samples: 23.931626 mean: 23.931626 min: 23.931626 max: 23.931626 stddev: NaN stddevpct: NaN
```
