### PR TITLE
feat: block fork PRs and skip CI for fork-originated pull requests

### DIFF
--- a/.github/workflows/crucible-ci.yaml
+++ b/.github/workflows/crucible-ci.yaml
@@ -27,13 +27,14 @@ jobs:
             .github/workflows/run-crucible-tracking.yaml
             .github/workflows/crucible-merged.yaml
             .github/workflows/crucible-ci.yaml
+            .github/workflows/fork-check.yaml
             docs/**
       - name: Display changes
         run: echo '${{ toJSON(steps.filter.outputs) }}' | jq .
 
   call-real-benchmark-crucible-ci:
     needs: changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.only-docs != 'true') }}
     uses: perftool-incubator/crucible-ci/.github/workflows/benchmark-crucible-ci.yaml@main
     with:
       ci_target: "uperf"
@@ -45,7 +46,7 @@ jobs:
 
   call-faux-benchmark-crucible-ci:
     needs: changes
-    if: ${{ github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.event_name != 'workflow_dispatch' && needs.changes.outputs.only-docs == 'true' }}
     uses: perftool-incubator/crucible-ci/.github/workflows/faux-benchmark-crucible-ci.yaml@main
 
   crucible-ci-complete:

--- a/.github/workflows/fork-check.yaml
+++ b/.github/workflows/fork-check.yaml
@@ -1,0 +1,27 @@
+name: fork-check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+jobs:
+  block-fork-pr:
+    if: github.event.pull_request.head.repo.fork == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close fork PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'This PR was opened from a fork. PRs must be opened from branches on the upstream repository so that CI workflows have access to required secrets and variables.\n\nPlease push your branch to this repository and open a new PR.\n\nClosing this PR automatically.'
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              state: 'closed'
+            });


### PR DESCRIPTION
## Summary
- Add `fork-check.yaml` workflow that automatically comments and closes PRs from forks
- Add fork guard to all PR-triggered CI workflows

Part of an org-wide rollout across all repos.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)