### PR TITLE
docs: update docs to reflect Python post-processor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Scripts and configuration to run the uperf network performance benchmark within 
 
 ## Languages
 - Bash: client, server, and runtime scripts
-- Perl: `uperf-post-process`
+- Python: `uperf-post-process.py`
 
 ## Key Files
 | File | Purpose |
@@ -21,4 +21,4 @@ Scripts and configuration to run the uperf network performance benchmark within 
 
 ## Conventions
 - Primary branch is `master`
-- Standard Bash/Perl modelines and 4-space indentation
+- Standard Bash modelines and 4-space indentation

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Name | Description
 uperf-base | Checks if the bench-base library can be sourced from the ${TOOLBOX_HOME}/bash/library/ directory. If the library cannot be sourced, the script prints an error message and exits with an exit status of 1.
 uperf-client | Runs a network benchmark using uperf, a network performance tool. The script has several command-line options that can be used to customize the benchmark run, including the number of threads, protocol, packet sizes, and duration.
 uperf-get-runtime | Outputs the duration of a benchmark run.
-uperf-post-process | Perl script that processes results from the uPerf benchmark tool and outputs a JSON file containing performance metrics. The JSON files adhere to a [Common Data Model (CDM) Schema](https://github.com/perftool-incubator/CommonDataModel).
+uperf-post-process.py | Processes results from the uPerf benchmark tool and outputs a JSON file containing performance metrics. The JSON files adhere to a [Common Data Model (CDM) Schema](https://github.com/perftool-incubator/CommonDataModel).
 uperf-server-start | Bash script that runs the uperf network performance benchmarking tool as a server. The script sets up the environment for running the tool and starts the server process with the specified parameters.
 uperf-server-stop | Stop a uperf server process. The script redirects standard output and standard error to a file named "uperf-server-stop-stderrout.txt".
 


### PR DESCRIPTION
## Summary
- Update CLAUDE.md and README.md to reflect that post-processor is now Python, not Perl
- Post-processor was ported in PR #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)