### PR TITLE
feat: write post-process-data.json to postprocess/ directory

### DIFF
--- a/uperf-post-process.py
+++ b/uperf-post-process.py
@@ -147,7 +147,7 @@ def main():
         ],
     }
 
-    with open("post-process-data.json", "w") as f:
+    with open("postprocess/post-process-data.json", "w") as f:
         json.dump(sample_data, f)
 
 


### PR DESCRIPTION
## Summary
- Write post-process-data.json to the postprocess/ subdirectory instead of the sample root directory
- Part of the Phase 2 migration for PERFNFV-316 (dedicated postprocess/ directory for all post-processing artifacts)

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Depends on
- toolbox PR #117 (merged) — CDMMetrics output_dir
- rickshaw PR #826 (merged) — orchestration creates/cleans postprocess/

🤖 Generated with [Claude Code](https://claude.com/claude-code)