### PR TITLE
feat: simplify service discovery using engine infrastructure

### DIFF
--- a/uperf-client
+++ b/uperf-client
@@ -129,22 +129,12 @@ fi
 # Unless the user specifies a specific remotehost argument, this must
 # be sourced from the endpoint (which gets it from the client)
 if [ -z "$remotehost" ]; then
-    echo "--remotehost was not set via cmdline args, checking any messages from the endpoint"
+    echo "--remotehost was not set via cmdline args, checking for resolved service info"
     echo "These files exist in ./msgs/rx:"
     /bin/ls -l msgs/rx
-    file="msgs/rx/endpoint-start-end:1"
-    if [ ! -e "${file}" ]; then
-	echo -n "Did not fine ${file}"
-	file="msgs/rx/server-start-end:1"
-	echo ", trying ${file}"
-    fi
-    if [ ! -e "${file}" ]; then
-	echo -n "Did not find ${file}"
-	file="msgs/rx/client-start:1"
-	echo ", trying ${file}"
-    fi
+    file="msgs/rx/svc"
     if [ -e "$file" ]; then
-        echo "Found $file"
+        echo "Found resolved service info: ${file}"
         ipaddr=`jq -r '.svc.ip' $file`
         if [ ! -z "$ipaddr" ]; then
             echo "Found server IP $ipaddr"

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -157,8 +157,8 @@ else
     echo "Not going to look for an IP since --ifname was not used."
 fi
 
-# Queue ip/port info, to be sent to endpoint
-echo '{"recipient":{"type":"all","id":"all"},"user-object":{"svc":{"ip":"'$ip'","ports":['$control_port,$data_port']}}}' >msgs/tx/svc
+# Queue service info for the engine infrastructure to deliver
+echo '{"svc":{"ip":"'$ip'","ports":['$control_port,$data_port']}}' >msgs/tx/svc
 
 echo "Existing listening ports:"
 ss -tlnp


### PR DESCRIPTION
## Summary
- Server writes raw JSON payload to `msgs/tx/svc` — no roadblock addressing
- Client reads resolved service info from `msgs/rx/svc` — no multi-file fallback chain
- Engine infrastructure (rickshaw PR #832) handles message addressing, targeting, and resolution

## Test plan
- [ ] Run single-pair uperf on remotehosts — verify `msgs/rx/svc` exists with correct IP/ports
- [ ] Run on kube — verify `msgs/rx/svc` has Service IP (not pod IP)
- [ ] Verify benchmark completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)