### PR TITLE
Fix uperf error handling checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Name | Description
 -----|------------
 multiplex.json | Defines presets and validations for the uperf network benchmarking tool. Presets include a set of arguments with predefined values, while validations provide regular expressions for validating the format of the arguments.
 rickshaw.json | Describes the configuration for the rickshaw-benchmark and how it interacts with the uperf benchmark, including which files should be transferred to the client and server, and which scripts to execute for starting and stopping the server and client.
-workshow.json | Specifies a workshop environment and requirements, including a source code requirement for the "uperf" tool that is downloaded from GitHub and compiled and installed with some specified commands. The environment has a default user environment which requires the "uperf_src" requirement.
+workshop.json | Specifies a workshop environment and requirements, including a source code requirement for the "uperf" tool that is downloaded from GitHub and compiled and installed with some specified commands. The environment has a default user environment which requires the "uperf_src" requirement.

--- a/uperf-client
+++ b/uperf-client
@@ -221,10 +221,10 @@ esac
 
 cmd+="${cpu_pin_cmd} uperf -R -m test.xml -P $control_port $uopts"
 
-# strip ',' from the passthru options 
+# strip ',' from the passthru options
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
 options+=" $passthru_opts"
-echo "passthu options: $options"
+echo "passthru options: $options"
 cmd+="$options"
 
 echo "going to run: ${cmd}"
@@ -239,8 +239,8 @@ port=$data_port \
 ${cmd} > uperf-client-result.txt 2>&1
 uperf_rc=$?
 uperf_errors=$(grep -i error uperf-client-result.txt)
-if [ ${uperf_rc} -gt 0 -o -z "${uperf_errors}" ]; then
-    if [ $test_type == "crr" ]; then
+if [ ${uperf_rc} -gt 0 -o -n "${uperf_errors}" ]; then
+    if [ "$test_type" == "crr" ]; then
         # Do not error on this, as it is sadly common for CRR, and the test will resume anyway
         exit 0
     fi

--- a/uperf-server-start
+++ b/uperf-server-start
@@ -131,7 +131,7 @@ if [ ! -z "$ifname" ]; then
         elif [ "$ipv" == "6" ]; then
             echo "$ifname matches index $ifname_idx, looking for ipv6 (inet6) in addr_info:"
             jq '.['$ifname_idx'].addr_info' ip.json
-            # Find the first ipv4 address
+            # Find the first ipv6 address
             addr_idx=`jq '.['$ifname_idx'].addr_info | to_entries | .[] | if (.value.family == "inet6") then .key else null end' ip.json | grep -v null | head -1`
             if [ ! -z $addr_idx ]; then
                 echo "Found inet in index $addr_idx:"
@@ -207,16 +207,16 @@ esac
 
 cmd="${cpu_pin_cmd} uperf -s -P $control_port"
 
-# strip ',' from the passthru options 
+# strip ',' from the passthru options
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
 options+=" $passthru_opts"
-echo "passthu options: $options"
+echo "passthru options: $options"
 
 cmd+="$options"
 
 echo "going to run: $cmd"
 export MALLOC_CHECK_=2
-$cmd 2>&1 >uperf-server-start.txt &
+$cmd >uperf-server-start.txt 2>&1 &
 pid=$!
 echo $pid >uperf-server.pid
 # Wait a little bit to see if the server errored out


### PR DESCRIPTION
﻿## Summary
- fix `uperf-client` so successful non-CRR runs with no error output do not enter the error handler
- redirect `uperf-server-start` stdout before stderr so startup errors are captured in the log file
- fix the reported passthru/workshop typos and the IPv6 comment

Closes #85.

## Validation
- `C:\Program Files\Git\bin\bash.exe -n uperf-client uperf-server-start`
- `rg -n "passthu|workshow|2>&1 >|-z \"\$\{uperf_errors\}\"" -S README.md uperf-client uperf-server-start`
- `rg -n "Find the first ipv4 address|Find the first ipv6 address" uperf-server-start`
- `git diff --check`

Generated with DevLoop-style issue diagnosis and manually reviewed before opening.
